### PR TITLE
Detect if sampling frequency is set to arbitrary/escape value, and le…

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/audio/AacUtil.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/audio/AacUtil.java
@@ -330,11 +330,16 @@ public final class AacUtil {
     int samplingFrequency;
     int frequencyIndex = bitArray.readBits(4);
     if (frequencyIndex == AUDIO_SPECIFIC_CONFIG_FREQUENCY_INDEX_ARBITRARY) {
+      if (bitArray.bitsLeft() < 24) {
+        throw ParserException.createForMalformedContainer(
+            /* message= */ "AAC header insufficient data", /* cause= */ null);
+      }
       samplingFrequency = bitArray.readBits(24);
     } else if (frequencyIndex < 13) {
       samplingFrequency = AUDIO_SPECIFIC_CONFIG_SAMPLING_RATE_TABLE[frequencyIndex];
     } else {
-      throw ParserException.createForMalformedContainer(/* message= */ null, /* cause= */ null);
+      throw ParserException.createForMalformedContainer(
+          /* message= */ "AAC header wrong Sampling Frequency Index", /* cause= */ null);
     }
     return samplingFrequency;
   }

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/audio/AacUtilTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/audio/AacUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer2.audio;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.util.Util;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Unit tests for {@link AacUtil}. */
+@RunWith(AndroidJUnit4.class)
+public final class AacUtilTest {
+  private static final byte[] AAC_48K_2CH_HEADER =
+      Util.getBytesFromHexString("1190");
+
+  private static final byte[] NOT_ENOUGH_ARBITRARY_SAMPLING_FREQ_BITS_HEADER =
+      Util.getBytesFromHexString("1790");
+
+  private static final byte[] ARBITRARY_SAMPLING_FREQ_BITS_HEADER =
+      Util.getBytesFromHexString("1780000790");
+
+  @Test
+  public void parseAudioSpecificConfig_twoCh48kAac() {
+    try {
+      AacUtil.Config aac = AacUtil.parseAudioSpecificConfig(AAC_48K_2CH_HEADER);
+      assertThat(aac.channelCount).isEqualTo(2);
+      assertThat(aac.sampleRateHz).isEqualTo(48000);
+      assertThat(aac.codecs).isEqualTo("mp4a.40.2");
+    } catch (ParserException e) {
+      fail("Exception thrown for a valid aac header");
+    }
+  }
+
+  @Test
+  public void parseAudioSpecificConfig_arbitrarySamplingFreqHeader() {
+    // ISO 14496-3 1.6.2.1 allows for setting of arbitrary sampling frequency.
+    try {
+      AacUtil.Config aac = AacUtil.parseAudioSpecificConfig(ARBITRARY_SAMPLING_FREQ_BITS_HEADER);
+      assertThat(aac.channelCount).isEqualTo(2);
+      assertThat(aac.sampleRateHz).isEqualTo(15); // random frequency of 15 Hz
+      assertThat(aac.codecs).isEqualTo("mp4a.40.2");
+    } catch (ParserException e) {
+      fail("Exception thrown for a valid aac header");
+    }
+  }
+
+  @Test
+  public void parseAudioSpecificConfig_arbitrarySamplingFreqHeader_notEnoughBits() {
+    // ISO 14496-3 1.6.2.1 allows for setting of arbitrary sampling frequency, but sometimes
+    // the extra frequency bits are missing, make sure the code will throw an exception.
+    assertThrows(ParserException.class,
+        () -> AacUtil.parseAudioSpecificConfig(NOT_ENOUGH_ARBITRARY_SAMPLING_FREQ_BITS_HEADER));
+  }
+
+}


### PR DESCRIPTION
…ss than 24 sampling frequency bits are present.

ISO ISO14496-3 allows setting of an arbitrary audio sampling frequency in compliant streams. When samplingFrequencyIndex is set to 0xf (escape value) we expect no less than 24 bits to read sampling informtion from (See section 1.6.2.1)